### PR TITLE
Fix qichacha error "No module named 'db.model'"

### DIFF
--- a/qichacha/crawler.py
+++ b/qichacha/crawler.py
@@ -8,7 +8,7 @@
 import logging as log
 from qichacha.client import QichachaClient
 from qichacha.manager import QichachaManager
-from db.model import Company
+from db.models import Company
 
 # 企查查客户端
 qcc_client = QichachaClient()


### PR DESCRIPTION
Catch an error with `python3 qichacha.py`.

```
Traceback (most recent call last):
  File "/Users/pinohans/Documents/project/jd/JDSecBJ/company-crawler/qichacha.py", line 8, in <module>
    from qichacha import crawler as QccCrawler
  File "/Users/pinohans/Documents/project/jd/JDSecBJ/company-crawler/qichacha/crawler.py", line 11, in <module>
    from db.model import Company
ModuleNotFoundError: No module named 'db.model'
```